### PR TITLE
Add dependency to cairo in build files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,8 +4,8 @@ plugindir=@rofi_PLUGIN_INSTALL_DIR@
 plugin_LTLIBRARIES = top.la
 
 top_la_SOURCES=\
-		 src/top.c
+     src/top.c
 
-top_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@
-top_la_LIBADD= @glib_LIBS@ @rofi_LIBS@
+top_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@ @cairo_CFLAGS@
+top_la_LIBADD= @glib_LIBS@ @rofi_LIBS@ @cairo_LIBS@
 top_la_LDFLAGS= -module -avoid-version

--- a/configure.ac
+++ b/configure.ac
@@ -49,9 +49,10 @@ PKG_PROG_PKG_CONFIG
 
 
 dnl ---------------------------------------------------------------------
-dnl PKG_CONFIG based dependencies  
+dnl PKG_CONFIG based dependencies
 dnl ---------------------------------------------------------------------
 PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0 libgtop-2.0])
+PKG_CHECK_MODULES([cairo],    [cairo])
 PKG_CHECK_MODULES([rofi],     [rofi])
 
 [rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"


### PR DESCRIPTION
Hi !

I was trying to build `rofi-top` on NixOS and saw that the dependency to `cairo` was missing.
I first added it as a patch for NixOS package but was asked to see if it could be upstreamed.

Can you confirm that it was missing ? 